### PR TITLE
Make plugin visible to cordova project in swift 4+

### DIFF
--- a/src/ios/CDVSearchAds.swift
+++ b/src/ios/CDVSearchAds.swift
@@ -11,7 +11,7 @@ import iAd
         )
     }
     
-    func initialize(_ command:CDVInvokedUrlCommand) {
+    @objc func initialize(_ command:CDVInvokedUrlCommand) {
         DispatchQueue.global().async {
             ADClient.shared().requestAttributionDetails({ (attributionDetails, error) in
                 if error == nil {


### PR DESCRIPTION
Fixes error:
[CDVCommandQueue executePending] [Line 142] FAILED pluginJSON = ["SearchAds355435108","SearchAds","initialize",[]]